### PR TITLE
🧪 [testing improvement] Add tests for profile view

### DIFF
--- a/apps/accounts/tests.py
+++ b/apps/accounts/tests.py
@@ -1,3 +1,56 @@
-from django.test import TestCase
+from django.test import TestCase, Client
+from django.contrib.auth.models import User
+from django.urls import reverse
+from .models import UserProfile
 
-# Create your tests here.
+class ProfileViewTest(TestCase):
+    def setUp(self):
+        self.username = 'testuser'
+        self.password = 'password123'
+        self.user = User.objects.create_user(username=self.username, password=self.password)
+        # UserProfile is created automatically via signal
+
+    def test_profile_view_get_authenticated(self):
+        self.client.login(username=self.username, password=self.password)
+        response = self.client.get(reverse('profile'))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'accounts/profile.html')
+        self.assertIn('user_form', response.context)
+        self.assertIn('profile_form', response.context)
+
+    def test_profile_view_get_anonymous(self):
+        response = self.client.get(reverse('profile'))
+        login_url = reverse('login')
+        expected_url = f"{login_url}?next={reverse('profile')}"
+        self.assertRedirects(response, expected_url)
+
+    def test_profile_view_post_valid(self):
+        self.client.login(username=self.username, password=self.password)
+        data = {
+            'first_name': 'New',
+            'last_name': 'Name',
+            'email': 'new@example.com',
+            'timezone': 'Europe/Stockholm'
+        }
+        response = self.client.post(reverse('profile'), data)
+        self.assertRedirects(response, reverse('profile'))
+
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.first_name, 'New')
+        self.assertEqual(self.user.last_name, 'Name')
+        self.assertEqual(self.user.email, 'new@example.com')
+        self.assertEqual(self.user.userprofile.timezone, 'Europe/Stockholm')
+
+    def test_profile_view_post_invalid(self):
+        self.client.login(username=self.username, password=self.password)
+        data = {
+            'first_name': 'New',
+            'last_name': 'Name',
+            'email': 'not-an-email',
+            'timezone': 'Invalid/Timezone'
+        }
+        response = self.client.post(reverse('profile'), data)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('user_form', response.context)
+        self.assertIn('profile_form', response.context)
+        self.assertTrue(response.context['user_form'].errors or response.context['profile_form'].errors)


### PR DESCRIPTION
This PR addresses the testing gap for the `profile` view in `apps/accounts/views.py`.

### 🎯 What
The `profile` view was previously untested. This PR adds a comprehensive test suite in `apps/accounts/tests.py` to ensure the view functions correctly under various conditions.

### 📊 Coverage
The new tests cover the following scenarios:
- **Authenticated GET**: Verifies that logged-in users can access the profile page and that the correct forms (`UserForm`, `UserProfileForm`) and template (`accounts/profile.html`) are used.
- **Anonymous GET**: Verifies that unauthenticated users are correctly redirected to the login page with the appropriate `next` parameter.
- **Valid POST**: Verifies that submitting valid data correctly updates both the `User` and `UserProfile` models, and that the user is redirected back to the profile page.
- **Invalid POST**: Verifies that submitting invalid data (e.g., malformed email) causes the view to re-render the forms with validation errors.

### ✨ Result
Increased test coverage and reliability for the user profile management functionality. The tests follow standard Django conventions and utilize `TestCase` for database isolation.

---
*PR created automatically by Jules for task [2179838427388100354](https://jules.google.com/task/2179838427388100354) started by @lg0killer*