### PR TITLE
Hide admin panel link from main page and add dropdown to profile menu

### DIFF
--- a/apps/news/templates/news/frontpage.html
+++ b/apps/news/templates/news/frontpage.html
@@ -112,7 +112,7 @@
         </div>
         {% empty %}
         <div style="text-align: center; width: 100%;">
-            <p>No news gathered yet. Check back after the morning scrape, or add sources in the <a href="/admin">Admin Panel</a>.</p>
+            <p>No news gathered yet. Check back after the morning scrape.</p>
         </div>
         {% endfor %}
     </div>

--- a/templates/base/base.html
+++ b/templates/base/base.html
@@ -65,6 +65,67 @@
             border-bottom: 1px solid var(--text-color);
         }
 
+        .user-dropdown-container {
+            display: inline-block;
+            position: relative;
+        }
+
+        .user-dropdown-toggle {
+            cursor: pointer;
+            border-bottom: 1px dashed var(--text-color);
+            padding-bottom: 2px;
+        }
+
+        .user-dropdown-menu {
+            display: none;
+            position: absolute;
+            right: 0;
+            top: 100%;
+            margin-top: 10px;
+            background-color: var(--bg-color);
+            border: 1px solid var(--line-color);
+            min-width: 150px;
+            z-index: 1000;
+            box-shadow: 2px 2px 5px rgba(0,0,0,0.1);
+        }
+
+        .user-dropdown-menu.show {
+            display: block;
+        }
+
+        .user-dropdown-menu a,
+        .user-dropdown-menu button {
+            display: block;
+            width: 100%;
+            text-align: left;
+            padding: 10px 15px;
+            box-sizing: border-box;
+            border: none;
+            border-bottom: 1px solid var(--line-color);
+            background: none;
+            color: var(--text-color);
+            font-family: inherit;
+            font-size: 1rem;
+            cursor: pointer;
+            text-decoration: none;
+            margin: 0;
+        }
+
+        .user-dropdown-menu a:last-child,
+        .user-dropdown-menu form:last-child button {
+            border-bottom: none;
+        }
+
+        .user-dropdown-menu a:hover,
+        .user-dropdown-menu button:hover {
+            background-color: #e8dcc3;
+            border-bottom: 1px solid var(--line-color);
+        }
+
+        .user-dropdown-menu form:last-child button:hover {
+            border-bottom: none;
+        }
+
         .form-container {
             max-width: 500px;
             margin: 0 auto;
@@ -138,12 +199,19 @@
     <div class="header">
         <div class="auth-links">
             {% if user.is_authenticated %}
-                <span>Welcome, {{ user.username }}</span>
-                <a href="{% url 'profile' %}">Profile</a>
-                <form action="{% url 'logout' %}" method="post" style="display:inline;">
-                    {% csrf_token %}
-                    <button type="submit" style="background:none; border:none; color:inherit; font-family:inherit; font-size:inherit; cursor:pointer; text-decoration:underline;">Logout</button>
-                </form>
+                <div class="user-dropdown-container">
+                    <span class="user-dropdown-toggle" id="userDropdownToggle" onclick="toggleDropdown()">Welcome, {{ user.username }} ▾</span>
+                    <div class="user-dropdown-menu" id="userDropdownMenu">
+                        <a href="{% url 'profile' %}">Profile</a>
+                        {% if user.is_staff %}
+                            <a href="/admin">Django Admin</a>
+                        {% endif %}
+                        <form action="{% url 'logout' %}" method="post">
+                            {% csrf_token %}
+                            <button type="submit">Logout</button>
+                        </form>
+                    </div>
+                </div>
             {% else %}
                 <a href="{% url 'login' %}">Login</a>
                 <a href="{% url 'signup' %}">Sign Up</a>
@@ -168,5 +236,23 @@
         {% endblock %}
     </div>
 
+    <script>
+        function toggleDropdown() {
+            document.getElementById("userDropdownMenu").classList.toggle("show");
+        }
+
+        // Close the dropdown if the user clicks outside of it
+        window.onclick = function(event) {
+            if (!event.target.matches('.user-dropdown-toggle')) {
+                var dropdowns = document.getElementsByClassName("user-dropdown-menu");
+                for (var i = 0; i < dropdowns.length; i++) {
+                    var openDropdown = dropdowns[i];
+                    if (openDropdown.classList.contains('show')) {
+                        openDropdown.classList.remove('show');
+                    }
+                }
+            }
+        }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
Hide admin panel link from main page and add dropdown to profile menu

This commit addresses the issue where the "Admin Panel" link was visible to all users on the main page when no news was gathered.
The message in `apps/news/templates/news/frontpage.html` has been updated to remove the reference to the Admin Panel.
Additionally, a new interactive dropdown menu has been added to the user's profile badge in `templates/base/base.html`.
This dropdown consolidates the "Profile" and "Logout" links and conditionally includes a "Django Admin" link that is only visible to staff users (`user.is_staff`).

---
*PR created automatically by Jules for task [7911015402118683955](https://jules.google.com/task/7911015402118683955) started by @lg0killer*