### PR TITLE
🧹 Replace print statements with logging in news utils

### DIFF
--- a/apps/news/utils.py
+++ b/apps/news/utils.py
@@ -1,9 +1,12 @@
+import logging
 import requests
 from bs4 import BeautifulSoup
 import argostranslate.package
 import argostranslate.translate
 from deep_translator import GoogleTranslator
 from .models import TranslationSetting
+
+logger = logging.getLogger(__name__)
 
 def detect_rss_feed(url):
     """
@@ -43,7 +46,7 @@ def detect_rss_feed(url):
                 pass
 
     except Exception as e:
-        print(f"Error detecting RSS for {url}: {e}")
+        logger.error(f"Error detecting RSS for {url}: {e}")
 
     return None
 
@@ -85,7 +88,7 @@ def translate_text(text, source_lang, target_lang='en'):
             return translator.translate(text)
 
     except Exception as e:
-        print(f"Translation error: {e}")
+        logger.error(f"Translation error: {e}")
         return text
 
     return text


### PR DESCRIPTION
🎯 **What:** Replaced `print` statements with `logger.error` in `apps/news/utils.py` for exception blocks.
💡 **Why:** Using the standard `logging` module improves code maintainability and allows for configurable logging levels and destinations, whereas `print` statements go directly to standard output and are hard to manage in production environments.
✅ **Verification:** Verified by compiling the file using `python3 -m py_compile` and running the project's test suite with `python manage.py test`. All tests passed.
✨ **Result:** Improved code health and maintainability by using proper logging instead of print statements for error reporting.

---
*PR created automatically by Jules for task [9944692207777623894](https://jules.google.com/task/9944692207777623894) started by @lg0killer*