### PR TITLE
🧹 Fix bare except blocks in news web scraper

### DIFF
--- a/apps/news/tasks.py
+++ b/apps/news/tasks.py
@@ -143,8 +143,8 @@ def run_web_scraper(source_id):
                     nav_href = nav.get_attribute('href')
                     if nav_text and len(nav_text) < 20 and nav_href:
                         category_names.append(nav_text)
-                except:
-                    pass
+                except Exception as e:
+                    logger.warning("[web] Error extracting nav link href: %s", e)
 
             # Collect article data without touching the DB
             items = page.locator('article, .article, .post, h2, h3').all()
@@ -164,8 +164,8 @@ def run_web_scraper(source_id):
                                 link = urljoin(source.url, href)
                             else:
                                 link = href
-                except:
-                    pass
+                except Exception as e:
+                    logger.warning("[web] Error extracting article link href: %s", e)
                 scraped_items.append({'headline': text, 'link': link})
 
             browser.close()


### PR DESCRIPTION
🎯 **What:** The bare `except:` blocks inside the Playwright scraping routine (`apps/news/tasks.py`) were modified to catch `Exception` explicitly and log a warning message.
💡 **Why:** Using bare `except:` blocks is a dangerous anti-pattern as it catches everything, including `KeyboardInterrupt` and `SystemExit`, breaking control flow. Also, silently suppressing these failures via `pass` makes it impossible to debug missing or broken site locators. By logging the exception, we enhance the overall maintainability and debuggability.
✅ **Verification:** A full run of the `apps.news` test suite and standard Django code compilation tools passed without error.
✨ **Result:** Safe, standardized error handling that improves code health and developer insight without impacting core functionality.

---
*PR created automatically by Jules for task [17467984273249959529](https://jules.google.com/task/17467984273249959529) started by @lg0killer*